### PR TITLE
Extension sections

### DIFF
--- a/fancy.tex
+++ b/fancy.tex
@@ -1,0 +1,40 @@
+\subsection{Indexing with a tensor of indices}
+
+Contributors: Tongfei Chen and Chu-Cheng Lin
+
+NumPy defines two kinds of \emph{advanced} (also known as \emph{fancy}) indexing: by integer arrays and by Boolean arrays. Here, we generalize indexing by integer arrays to named tensors. That is, if $A$ is a named tensor with $D$ indices and $I^1, \ldots, I^D$ are named tensors, called ``indexers,'' what is $A_{I^1, \ldots, I^D}$?
+
+We first consider the case where all the indexers have the same shape $\mathcal{S}$:
+\begin{align*}
+  A &\in F^{\nidx{i\sub{1}}{X_1}, \ldots, \nidx{i\sub{D}}{X_D}} \\
+  I^d &\in X_D^{\mathcal{S}} & d &= 1, \ldots, D.
+\end{align*}
+Then $A_{I^1, \ldots, I^D}$ is the named tensor with shape $\mathcal{S}$ such that for any $s \in \tupleshape{\mathcal{S}}$,
+\begin{align*}
+  [A_{I^1, \ldots, I^D}]_s &= A_{I^1_s, \ldots, I^D_s}.
+\end{align*}
+More generally, suppose the indexers have different but compatible shapes:
+\begin{align*}
+  A &\in F^{\nidx{i\sub{1}}{X_1}, \ldots, \nidx{i\sub{D}}{X_D}} \\
+  I^d &\in X_D^{\mathcal{S}_d} & d &= 1, \ldots, D,
+\end{align*}
+where the $\mathcal{S}_d$ are pairwise compatible. Then $A_{I^1, \ldots, I^D}$ is the named tensor with shape $\mathcal{S} = \bigcup_d \mathcal{S}_d$ such that for any $s \in \tupleshape{\mathcal{S}}$,
+\begin{align*}
+  [A_{I^1, \ldots, I^D}]_s &= A_{I^1_{\tuplerestrict{s}{\mathcal{S}_1}}, \ldots, I^D_{\tuplerestrict{s}{\mathcal{S}_D}}}.
+\end{align*}
+
+Let's consider a concrete example in natural language processing. Consider a batch of sentences encoded as a sequence of word vectors, that is, a tensor $X \in \mathbb{R}^{\nset{batch}{B}, \nset{sent}{N}, \nset{emb}{E}}$. For each sentence, we would like to take out the encodings of a particular span for each sentence $b \in [B]$ in the batch, resulting in a tensor $Y \in \mathbb{R}^{\nset{batch}{B}, \nset{span}{M}, \nset{emb}{E}}$.
+
+We create a indexer for the $\name{sent}$ axis: $I_{\name{sent}} \in [N]^{\name{batch}:B \times \name{span}: M}$ that selects the desired tokens. Then we can write
+\begin{equation*}
+  Y = X_{\nidx{batch}{I}, \nidx{sent}{I}, \nidx{emb}{I}}
+\end{equation*}
+where the other two indexers
+\begin{align*}
+  I_{\name{batch}} &\in [B]^{\nset{batch}{B}} \\
+  [I_{\name{batch}}]_{\nidx{batch}{b}} &= b \\
+  I_{\name{emb}} &\in [E]^{\nset{emb}{E}} \\
+  [I_{\name{sent}}]_{\nidx{sent}{n}} &= n
+\end{align*}
+select all values of their respective indices.
+

--- a/types.tex
+++ b/types.tex
@@ -1,0 +1,28 @@
+\subsection{Index types}
+
+We have defined a named index set as a pair $\nset{i}{X}$, where $\name{i}$ is a name and $X$ is a set, usually $[n]$ for some $n$. In this section, we consider some other possibilities for~$X$.
+
+\subsubsection{Non-integral types}
+
+The sets $X$ don't have to contain integers. For example, if $V$ is the vocabulary of a natural language ($V = \{ \text{cat}, \text{dog}, \ldots \}$), we could define a matrix of word embeddings:
+\begin{align*}
+  E &\in \mathbb{R}^{\nidx{vocab}{V} \times \nidx{emb}{d}}.
+\end{align*}
+
+\subsubsection{Integers with units}
+
+If $\name{u}$ is a symbol and $n > 0$, define $[n]\name{u} = \{1\name{u}, 2\name{u}, \ldots, n\name{u}\}$. You could think of $\name{u}$ as analogous to a physical unit like kilograms. The set $[n]\name{u}$ could be used as an index set, which would prevent the index from being aligned with another index that uses different units. For example, if we want to define a tensor representing an image, we might write
+\[ A \in \mathbb{R}^{\nidx{height}{[h]\name{px} \times \nidx{width}{[w]\name{px}}}}. \]
+
+\subsubsection{Tuples of integers}
+
+An index set could also be $[m] \times [n]$, which would be a way of sneaking ordered indices into named tensors, useful for matrix operations. For example, instead of defining an $\text{inv}$ operator that takes two subscripts, we could write
+\begin{align*}
+  A &\in \mathbb{R}^{\nidx{d}{{m\times n}}} = \mathbb{R}^{\nidx{d}{{[m]\times [n]}}} \\
+  B &= \nfun{d}{inv} A.
+\end{align*}
+We could also define an operator $\circ$ for matrix-matrix and matrix-vector multiplication:
+\begin{align*}
+  c &\in \mathbb{R}^{\nidx{d}{n}} \\
+  D &= A \nbin{d}{\circ} B \nbin{d}{\circ} c.
+\end{align*}


### PR DESCRIPTION
I'm thinking that to make it easy for people to adopt our notation, we should keep the core as simple as possible, but put more complex ideas into an "Extensions" section. This PR adds two short extensions, in addition to the existing proposed extensions for dual vector spaces.

- index types other than natural numbers, from #18
- fancy indexing, from #6

@srush, do you think this is a good way to organize?
